### PR TITLE
Testing PENN CNB REDCap

### DIFF
--- a/lochness/helpers/config.py
+++ b/lochness/helpers/config.py
@@ -28,7 +28,12 @@ def parse(path: Path, section: str) -> Dict[str, str]:
     if parser.has_section(section):
         params = parser.items(section)
         for param in params:
-            conf[param[0]] = param[1]
+            if param[1].lower() == 'true':
+                conf[param[0]] = True
+            elif param[1].lower() == 'false':
+                conf[param[0]] = False
+            else:
+                conf[param[0]] = param[1]
     else:
         raise ValueError(f"Section {section} not found in the {path} file")
 

--- a/lochness/helpers/config.py
+++ b/lochness/helpers/config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Dict
 
 
-def parse(path: Path, section: str) -> Dict[str, str]:
+def parse(path: Path, section: str) -> Dict[str, str | bool]:
     """
     Read the configuration file and return a dictionary of parameters for the given section.
 

--- a/lochness/sources/redcap/models/data_source.py
+++ b/lochness/sources/redcap/models/data_source.py
@@ -20,6 +20,7 @@ class RedcapDataSourceMetadata(BaseModel):
     optional_variables_dictionary: List[Dict[str, str]]
     main_redcap: bool = False
     subject_id_variable: Optional[str]
+    subject_id_variable_as_the_pk: bool = True
 
 
 class RedcapDataSource(BaseModel):

--- a/lochness/sources/redcap/models/data_source.py
+++ b/lochness/sources/redcap/models/data_source.py
@@ -21,6 +21,7 @@ class RedcapDataSourceMetadata(BaseModel):
     main_redcap: bool = False
     subject_id_variable: Optional[str]
     subject_id_variable_as_the_pk: bool = True
+    messy_subject_id: bool = False
 
 
 class RedcapDataSource(BaseModel):

--- a/lochness/sources/redcap/models/data_source.py
+++ b/lochness/sources/redcap/models/data_source.py
@@ -93,6 +93,7 @@ class RedcapDataSource(BaseModel):
                         "subject_id_variable"
                     ],
                     optional_variables_dictionary=optional_variables,
+                    main_redcap=row["data_source_metadata"]["main_redcap"],
                 ),
             )
             return redcap_data_source

--- a/lochness/sources/redcap/tasks/pull_data.py
+++ b/lochness/sources/redcap/tasks/pull_data.py
@@ -42,6 +42,11 @@ logargs: Dict[str, Any] = {
 logging.basicConfig(**logargs)
 
 
+
+def build_query_dict_for_penncnb(subject_id: str,
+                                 subject_id_variable: str):
+    pass
+
 def fetch_subject_data(
     redcap_data_source: RedcapDataSource,
     subject_id: str,

--- a/lochness/sources/redcap/tasks/pull_data.py
+++ b/lochness/sources/redcap/tasks/pull_data.py
@@ -77,6 +77,8 @@ def add_filter_logic_for_penncnb_redcap(filter_logic: str,
             # f"contains([{subject_id_var}], '{subject_id}={x}')"
             # for x in digits_str]
 
+    filter_logic = f"[{subject_id_var}] = '{subject_id}' or " \
+            f"[{subject_id_var}] = '{subject_id.lower()}'"
     # filter_logic += f"or {' or '.join(contains_logic)}"
     # return filter_logic
     contains_logic = []
@@ -139,14 +141,14 @@ def fetch_subject_data(
     else:
         subject_id_var = redcap_data_source.\
                 data_source_metadata.subject_id_variable
-        filter_logic = f"[{subject_id_var}] = '{subject_id}' or " \
-                f"[{subject_id_var}] = '{subject_id.lower()}'"
+        filter_logic = ''
 
         if redcap_data_source.\
                 data_source_metadata.messy_subject_id:
             filter_logic = add_filter_logic_for_penncnb_redcap(
                     filter_logic, subject_id, subject_id_var)
 
+        filter_logic = ''
         print(filter_logic)
         data = {
             "token": api_token,

--- a/lochness/sources/redcap/tasks/pull_data.py
+++ b/lochness/sources/redcap/tasks/pull_data.py
@@ -66,18 +66,27 @@ def add_filter_logic_for_penncnb_redcap(filter_logic: str,
         str: The enhanced filter logic string with additional conditions 
              included for handling various subject ID suffix patterns.
     """
-    digits = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-    digits_str = [str(x) for x in digits]
+    # digits = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    # digits_str = [str(x) for x in digits]
+    # contains_logic = []
+    # for subject_id in [subject_id, subject_id.lower()]:
+        # contains_logic += [
+            # f"contains([{subject_id_var}], '{subject_id}_{x}')"
+            # for x in digits_str]
+        # contains_logic += [
+            # f"contains([{subject_id_var}], '{subject_id}={x}')"
+            # for x in digits_str]
+
+    # filter_logic += f"or {' or '.join(contains_logic)}"
+    # return filter_logic
     contains_logic = []
     for subject_id in [subject_id, subject_id.lower()]:
         contains_logic += [
-            f"contains([{subject_id_var}], '{subject_id}_{x}')"
-            for x in digits_str]
+            f"[{subject_id_var}] like '{subject_id}_%'"]
         contains_logic += [
-            f"contains([{subject_id_var}], '{subject_id}={x}')"
-            for x in digits_str]
+            f"[{subject_id_var}] like '{subject_id}=%'"]
 
-    filter_logic += f"or {' or '.join(contains_logic)}"
+    filter_logic += f" or {' or '.join(contains_logic)}"
     return filter_logic
 
 
@@ -138,6 +147,7 @@ def fetch_subject_data(
             filter_logic = add_filter_logic_for_penncnb_redcap(
                     filter_logic, subject_id, subject_id_var)
 
+        print(filter_logic)
         data = {
             "token": api_token,
             "content": "record",
@@ -153,6 +163,11 @@ def fetch_subject_data(
             "exportDataAccessGroups": "false",
             "filterLogic": filter_logic, # Export data for this specific subject
         }
+        print(data)
+        import json
+        with open('tmp.json', 'w') as fp:
+            json.dump(data, fp, indent=4)
+        
 
     try:
         r = requests.post(redcap_endpoint_url, data=data, timeout=timeout_s)

--- a/lochness/sources/redcap/tasks/pull_data.py
+++ b/lochness/sources/redcap/tasks/pull_data.py
@@ -66,27 +66,19 @@ def add_filter_logic_for_penncnb_redcap(filter_logic: str,
         str: The enhanced filter logic string with additional conditions 
              included for handling various subject ID suffix patterns.
     """
-    # digits = [1, 2, 3, 4, 5, 6, 7, 8, 9]
-    # digits_str = [str(x) for x in digits]
-    # contains_logic = []
-    # for subject_id in [subject_id, subject_id.lower()]:
-        # contains_logic += [
-            # f"contains([{subject_id_var}], '{subject_id}_{x}')"
-            # for x in digits_str]
-        # contains_logic += [
-            # f"contains([{subject_id_var}], '{subject_id}={x}')"
-            # for x in digits_str]
-
     filter_logic = f"[{subject_id_var}] = '{subject_id}' or " \
             f"[{subject_id_var}] = '{subject_id.lower()}'"
-    # filter_logic += f"or {' or '.join(contains_logic)}"
-    # return filter_logic
+
+    digits = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    digits_str = [str(x) for x in digits]
     contains_logic = []
     for subject_id in [subject_id, subject_id.lower()]:
         contains_logic += [
-            f"[{subject_id_var}] like '{subject_id}_%'"]
+            f"contains([{subject_id_var}], '{subject_id}_{x}')"
+            for x in digits_str]
         contains_logic += [
-            f"[{subject_id_var}] like '{subject_id}=%'"]
+            f"contains([{subject_id_var}], '{subject_id}={x}')"
+            for x in digits_str]
 
     filter_logic += f" or {' or '.join(contains_logic)}"
     return filter_logic
@@ -148,8 +140,6 @@ def fetch_subject_data(
             filter_logic = add_filter_logic_for_penncnb_redcap(
                     filter_logic, subject_id, subject_id_var)
 
-        filter_logic = ''
-        print(filter_logic)
         data = {
             "token": api_token,
             "content": "record",
@@ -165,11 +155,6 @@ def fetch_subject_data(
             "exportDataAccessGroups": "false",
             "filterLogic": filter_logic, # Export data for this specific subject
         }
-        print(data)
-        import json
-        with open('tmp.json', 'w') as fp:
-            json.dump(data, fp, indent=4)
-        
 
     try:
         r = requests.post(redcap_endpoint_url, data=data, timeout=timeout_s)

--- a/lochness/sources/redcap/tasks/refresh_metadata.py
+++ b/lochness/sources/redcap/tasks/refresh_metadata.py
@@ -231,7 +231,7 @@ def refresh_all_metadata(config_file: Path,
     # make sure they have subject_id_variable in metadata
     active_redcap_data_sources = [
             ds for ds in active_redcap_data_sources
-            if ds.data_source_metadata.main_redcap == True)]
+            if ds.data_source_metadata.main_redcap == True]
 
     # Filter by project_id and/or site_id if provided
     if project_id:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pytest
+pandas
+psycopg2-binary
+sqlalchemy
+rich
+pydantic
+minio

--- a/test/lochness/sources/redcap/tasks/test_pull_data.py
+++ b/test/lochness/sources/redcap/tasks/test_pull_data.py
@@ -100,6 +100,7 @@ def test_penncnb_fetch_subject_data(prod_data_fixture):
             SUBJECT_ID,
             encryption_passphrase)
 
+    print(data)
     assert len(data) > 100
 
 

--- a/test/lochness/sources/redcap/tasks/test_pull_data.py
+++ b/test/lochness/sources/redcap/tasks/test_pull_data.py
@@ -67,6 +67,39 @@ def test_fetch_subject_data(prod_data_fixture):
 
     assert len(data) > 100
 
+
+def test_penncnb_fetch_subject_data(prod_data_fixture):
+    PROJECT_ID, PROJECT_NAME, SITE_ID, \
+            SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
+
+    config_file = utils.get_config_file_path()
+    encryption_passphrase = config.parse(config_file, 'general')[
+            'encryption_passphrase']
+    redcap_cred = config.parse(config_file, 'redcap-penncnb-test')
+    data_source_name = redcap_cred['data_source_name']
+
+    redcapDataSourceMetadata = RedcapDataSourceMetadata(
+            keystore_name=redcap_cred['key_name'],
+            endpoint_url=redcap_cred['endpoint_url'],
+            subject_id_variable=redcap_cred['subject_id_variable'],
+            optional_variables_dictionary=[])
+
+    redcapDataSource = RedcapDataSource(
+        data_source_name=data_source_name,
+        is_active=True,
+        site_id=SITE_ID,
+        project_id=PROJECT_ID,
+        data_source_type='redcap',
+        data_source_metadata=redcapDataSourceMetadata)
+
+    data = fetch_subject_data(
+            redcapDataSource,
+            SUBJECT_ID,
+            encryption_passphrase)
+
+    assert len(data) > 100
+
+
 def test_save_subject_data(prod_data_fixture):
     PROJECT_ID, PROJECT_NAME, SITE_ID, \
             SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture

--- a/test/lochness/sources/redcap/tasks/test_pull_data.py
+++ b/test/lochness/sources/redcap/tasks/test_pull_data.py
@@ -2,6 +2,7 @@ import os
 import sys
 import shutil
 from pathlib import Path
+import pytest
 
 for x in sys.path:
     if 'lochness' in x:
@@ -18,251 +19,143 @@ sys.path.append(str(root_dir))
 sys.path.append(str(root_dir / 'test'))
 from test_module import fake_data_fixture, config_file, prod_data_fixture
 from lochness.sources.redcap.models.data_source import (
-        RedcapDataSourceMetadata,
-        RedcapDataSource
-        )
+    RedcapDataSourceMetadata,
+    RedcapDataSource
+)
 from lochness.sources.redcap.tasks.refresh_metadata import refresh_all_metadata
 from lochness.sources.redcap.tasks.pull_data import (
-        fetch_subject_data,
-        save_subject_data,
-        pull_all_data
-        )
+    fetch_subject_data,
+    save_subject_data,
+    pull_all_data
+)
 from lochness.models.subjects import Subject
 from lochness.models.data_pulls import DataPull
 from lochness.helpers import logs, utils, db, config
+
+
+def make_redcap_data_source(config_file, config_section, site_id, project_id):
+    cred = config.parse(config_file, config_section)
+    metadata_kwargs = dict(
+        keystore_name=cred['key_name'],
+        endpoint_url=cred['endpoint_url'],
+        subject_id_variable=cred['subject_id_variable'],
+        optional_variables_dictionary=[]
+    )
+    # Add optional keys if present
+    for key in ['subject_id_variable_as_the_pk', 'messy_subject_id']:
+        if key in cred:
+            metadata_kwargs[key] = cred[key]
+    metadata = RedcapDataSourceMetadata(**metadata_kwargs)
+    return RedcapDataSource(
+        data_source_name=cred['data_source_name'],
+        is_active=True,
+        site_id=site_id,
+        project_id=project_id,
+        data_source_type='redcap',
+        data_source_metadata=metadata
+    )
+
+
+def get_encryption_passphrase(config_file):
+    return config.parse(config_file, 'general')['encryption_passphrase']
+
+
+def get_output_file_path(config_file, project_id, site_id, subject_id, data_source_name):
+    lochness_root = config.parse(config_file, 'general')['lochness_root']
+    project_name_cap = project_id[:1].upper() + project_id[1:].lower()
+    output_dir = (
+        Path(lochness_root)
+        / project_name_cap
+        / "PHOENIX"
+        / "PROTECTED"
+        / f"{project_name_cap}{site_id}"
+        / "raw"
+        / subject_id
+        / "surveys"
+    )
+    file_name = f"{subject_id}.{project_name_cap}.{data_source_name}.json"
+    return output_dir / file_name
+
+
+def assert_file_and_db(config_file, file_path, project_id, site_id, subject_id):
+    assert file_path.is_file()
+    # DB checks
+    data_pull_query = f"""SELECT subject_id FROM data_pull
+    WHERE subject_id = '{subject_id}'
+      AND project_id = '{project_id}'
+      AND site_id = '{site_id}'
+      AND file_path = '{file_path}'
+      """
+    df = db.execute_sql(config_file, data_pull_query)
+    assert len(df) > 0
+    files_query = f"""SELECT file_path FROM files
+    WHERE file_path = '{file_path}'
+      """
+    df = db.execute_sql(config_file, files_query)
+    assert len(df) > 0
+    data_push_query = f"""SELECT file_path FROM data_push
+    WHERE file_path = '{file_path}'
+      """
+    df = db.execute_sql(config_file, data_push_query)
+    assert len(df) > 0
+
+
+def cleanup_output(config_file, project_id):
+    lochness_root = config.parse(config_file, 'general')['lochness_root']
+    project_name_cap = project_id[:1].upper() + project_id[1:].lower()
+    outdir_root = Path(lochness_root) / project_name_cap
+    shutil.rmtree(outdir_root)
 
 
 def test_init():
     pass
 
 
-def test_fetch_subject_data(prod_data_fixture):
-    PROJECT_ID, PROJECT_NAME, SITE_ID, \
-            SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
-
+def test_fetch_subject_data_redcap(prod_data_fixture):
+    PROJECT_ID, PROJECT_NAME, SITE_ID, SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
     config_file = utils.get_config_file_path()
-    encryption_passphrase = config.parse(config_file, 'general')[
-            'encryption_passphrase']
-    redcap_cred = config.parse(config_file, 'redcap-test')
-    data_source_name = redcap_cred['data_source_name']
-
-    redcapDataSourceMetadata = RedcapDataSourceMetadata(
-            keystore_name=redcap_cred['key_name'],
-            endpoint_url=redcap_cred['endpoint_url'],
-            subject_id_variable=redcap_cred['subject_id_variable'],
-            optional_variables_dictionary=[])
-
-    redcapDataSource = RedcapDataSource(
-        data_source_name=data_source_name,
-        is_active=True,
-        site_id=SITE_ID,
-        project_id=PROJECT_ID,
-        data_source_type='redcap',
-        data_source_metadata=redcapDataSourceMetadata)
-
-    data = fetch_subject_data(
-            redcapDataSource,
-            SUBJECT_ID,
-            encryption_passphrase)
-
+    encryption_passphrase = get_encryption_passphrase(config_file)
+    data_source = make_redcap_data_source(config_file, "redcap-test", SITE_ID, PROJECT_ID)
+    data = fetch_subject_data(data_source, SUBJECT_ID, encryption_passphrase)
     assert len(data) > 100
 
 
-def test_penncnb_fetch_subject_data(prod_data_fixture):
-    PROJECT_ID, PROJECT_NAME, SITE_ID, \
-            SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
+def test_fetch_subject_data_penncnb(prod_data_fixture):
+    PROJECT_ID, PROJECT_NAME, SITE_ID, SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
+    SUBJECT_ID=config.parse(config_file, 'prod-test-info')['subject_id_penncnb']
 
     config_file = utils.get_config_file_path()
-    encryption_passphrase = config.parse(config_file, 'general')[
-            'encryption_passphrase']
-    redcap_penncnb_cred = config.parse(config_file, 'redcap-penncnb-test')
-    data_source_name = redcap_penncnb_cred['data_source_name']
-
-    redcapDataSourceMetadata = RedcapDataSourceMetadata(
-            keystore_name=redcap_penncnb_cred['key_name'],
-            endpoint_url=redcap_penncnb_cred['endpoint_url'],
-            subject_id_variable=redcap_penncnb_cred['subject_id_variable'],
-            subject_id_variable_as_the_pk=
-                redcap_penncnb_cred['subject_id_variable_as_the_pk'],
-            messy_subject_id=redcap_penncnb_cred['messy_subject_id'],
-            optional_variables_dictionary=[])
-
-    redcapDataSource = RedcapDataSource(
-        data_source_name=data_source_name,
-        is_active=True,
-        site_id=SITE_ID,
-        project_id=PROJECT_ID,
-        data_source_type='redcap',
-        data_source_metadata=redcapDataSourceMetadata)
-
-    data = fetch_subject_data(
-            redcapDataSource,
-            SUBJECT_ID,
-            encryption_passphrase)
-
-    assert len(data) > 100
+    encryption_passphrase = get_encryption_passphrase(config_file)
+    data_source = make_redcap_data_source(config_file, "redcap-penncnb-test", SITE_ID, PROJECT_ID)
+    data = fetch_subject_data(data_source, SUBJECT_ID, encryption_passphrase)
+    assert len(data) < 100
 
 
-def test_save_subject_data(prod_data_fixture):
-    PROJECT_ID, PROJECT_NAME, SITE_ID, \
-            SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
-
+@pytest.mark.parametrize("config_section", ["redcap-test", "redcap-penncnb-test"])
+def test_save_subject_data(prod_data_fixture, config_section):
+    PROJECT_ID, PROJECT_NAME, SITE_ID, SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
     config_file = utils.get_config_file_path()
-    encryption_passphrase = config.parse(config_file, 'general')[
-            'encryption_passphrase']
-    redcap_cred = config.parse(config_file, 'redcap-test')
-    data_source_name = redcap_cred['data_source_name']
-
-    redcapDataSourceMetadata = RedcapDataSourceMetadata(
-            keystore_name=redcap_cred['key_name'],
-            endpoint_url=redcap_cred['endpoint_url'],
-            subject_id_variable=redcap_cred['subject_id_variable'],
-            subject_id_variable_as_the_pk=
-                redcap_cred['subject_id_variable_as_the_pk'],
-            messy_subject_id=redcap_cred['messy_subject_id'],
-            optional_variables_dictionary=[])
-
-    redcapDataSource = RedcapDataSource(
-        data_source_name=data_source_name,
-        is_active=True,
-        site_id=SITE_ID,
-        project_id=PROJECT_ID,
-        data_source_type='redcap',
-        data_source_metadata=redcapDataSourceMetadata)
-
-    data = fetch_subject_data(
-            redcapDataSource,
-            SUBJECT_ID,
-            encryption_passphrase)
-
-    assert save_subject_data(data, PROJECT_ID, SITE_ID, SUBJECT_ID, 
-                             data_source_name, config_file)
-
-    lochness_root = config.parse(config_file, 'general')['lochness_root']
-    project_name_cap = PROJECT_ID[:1].upper() + \
-            PROJECT_ID[1:].lower()
-
-    output_dir = (
-        Path(lochness_root)
-        / project_name_cap
-        / "PHOENIX"
-        / "PROTECTED"
-        / f"{project_name_cap}{SITE_ID}"
-        / "raw"
-        / SUBJECT_ID
-        / "surveys"
-    )
-    file_name = f"{SUBJECT_ID}.{project_name_cap}.{data_source_name}.json"
-    file_path = output_dir / file_name
+    encryption_passphrase = get_encryption_passphrase(config_file)
+    data_source = make_redcap_data_source(config_file, config_section, SITE_ID, PROJECT_ID)
+    data = fetch_subject_data(data_source, SUBJECT_ID, encryption_passphrase)
+    assert save_subject_data(data, PROJECT_ID, SITE_ID, SUBJECT_ID, data_source.data_source_name, config_file)
+    file_path = get_output_file_path(config_file, PROJECT_ID, SITE_ID, SUBJECT_ID, data_source.data_source_name)
     assert file_path.is_file()
 
 
-def test_penncnb_save_subject_data(prod_data_fixture):
-    PROJECT_ID, PROJECT_NAME, SITE_ID, \
-            SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
+@pytest.mark.parametrize("config_section", ["redcap-test", "redcap-penncnb-test"])
+def test_pull_and_push_single_data(prod_data_fixture, config_section):
+    PROJECT_ID, PROJECT_NAME, SITE_ID, SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
 
+    SUBJECT_ID=config.parse(config_file, 'prod-test-info')['subject_id_penncnb']
     config_file = utils.get_config_file_path()
-    encryption_passphrase = config.parse(config_file, 'general')[
-            'encryption_passphrase']
-    redcap_penncnb_cred = config.parse(config_file, 'redcap-penncnb-test')
-    data_source_name = redcap_penncnb_cred['data_source_name']
-
-    redcapDataSourceMetadata = RedcapDataSourceMetadata(
-            keystore_name=redcap_penncnb_cred['key_name'],
-            endpoint_url=redcap_penncnb_cred['endpoint_url'],
-            subject_id_variable=redcap_penncnb_cred['subject_id_variable'],
-            subject_id_variable_as_the_pk=
-                redcap_penncnb_cred['subject_id_variable_as_the_pk'],
-            messy_subject_id=redcap_penncnb_cred['messy_subject_id'],
-            optional_variables_dictionary=[])
-
-    redcapDataSource = RedcapDataSource(
-        data_source_name=data_source_name,
-        is_active=True,
-        site_id=SITE_ID,
-        project_id=PROJECT_ID,
-        data_source_type='redcap',
-        data_source_metadata=redcapDataSourceMetadata)
-
-    data = fetch_subject_data(
-            redcapDataSource,
-            SUBJECT_ID,
-            encryption_passphrase)
-
-    assert save_subject_data(data, PROJECT_ID, SITE_ID, SUBJECT_ID, 
-                             data_source_name, config_file)
-
-    lochness_root = config.parse(config_file, 'general')['lochness_root']
-    project_name_cap = PROJECT_ID[:1].upper() + \
-            PROJECT_ID[1:].lower()
-
-    output_dir = (
-        Path(lochness_root)
-        / project_name_cap
-        / "PHOENIX"
-        / "PROTECTED"
-        / f"{project_name_cap}{SITE_ID}"
-        / "raw"
-        / SUBJECT_ID
-        / "surveys"
-    )
-    file_name = f"{SUBJECT_ID}.{project_name_cap}.{data_source_name}.json"
-    file_path = output_dir / file_name
-    assert file_path.is_file()
-
-
-def test_pull_and_push_single_data(prod_data_fixture):
-    PROJECT_ID, PROJECT_NAME, SITE_ID, \
-            SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
-    config_file = utils.get_config_file_path()
-
     refresh_all_metadata(config_file, PROJECT_ID, SITE_ID)
     pull_all_data(config_file=config_file,
                   project_id=PROJECT_ID,
                   site_id=SITE_ID,
                   subject_id_list=[SUBJECT_ID],
                   push_to_sink=True)
-
-    lochness_root = config.parse(config_file, 'general')['lochness_root']
-    project_name_cap = PROJECT_ID[:1].upper() + \
-            PROJECT_ID[1:].lower()
-    outdir_root = Path(lochness_root) / project_name_cap
-
-    redcap_cred = config.parse(config_file, 'redcap-test')
-    data_source_name = redcap_cred['data_source_name']
-    output_dir = (outdir_root
-        / "PHOENIX"
-        / "PROTECTED"
-        / f"{project_name_cap}{SITE_ID}"
-        / "raw"
-        / SUBJECT_ID
-        / "surveys"
-    )
-    file_name = f"{SUBJECT_ID}.{project_name_cap}.{data_source_name}.json"
-    file_path = output_dir / file_name
-
-    assert file_path.is_file()
-    
-    # make sure the function has added records to DB
-    data_pull_qeury = f"""SELECT subject_id FROM data_pull
-    WHERE subject_id = '{SUBJECT_ID}'
-      AND project_id = '{PROJECT_ID}'
-      AND site_id = '{SITE_ID}'
-      AND file_path = '{file_path}'
-      """
-    df = db.execute_sql(config_file, data_pull_qeury)
-    assert len(df) > 0
-
-    files_qeury = f"""SELECT file_path FROM files
-    WHERE file_path = '{file_path}'
-      """
-    df = db.execute_sql(config_file, files_qeury)
-    assert len(df) > 0
-
-    data_push_qeury = f"""SELECT file_path FROM data_push
-    WHERE file_path = '{file_path}'
-      """
-    df = db.execute_sql(config_file, data_push_qeury)
-    assert len(df) > 0
-
-    # shutil.rmtree(outdir_root)
+    data_source = make_redcap_data_source(config_file, config_section, SITE_ID, PROJECT_ID)
+    file_path = get_output_file_path(config_file, PROJECT_ID, SITE_ID, SUBJECT_ID, data_source.data_source_name)
+    assert_file_and_db(config_file, file_path, PROJECT_ID, SITE_ID, SUBJECT_ID)
+    cleanup_output(config_file, PROJECT_ID)

--- a/test/lochness/sources/redcap/tasks/test_pull_data.py
+++ b/test/lochness/sources/redcap/tasks/test_pull_data.py
@@ -122,9 +122,9 @@ def test_fetch_subject_data_redcap(prod_data_fixture):
 
 def test_fetch_subject_data_penncnb(prod_data_fixture):
     PROJECT_ID, PROJECT_NAME, SITE_ID, SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
+    config_file = utils.get_config_file_path()
     SUBJECT_ID=config.parse(config_file, 'prod-test-info')['subject_id_penncnb']
 
-    config_file = utils.get_config_file_path()
     encryption_passphrase = get_encryption_passphrase(config_file)
     data_source = make_redcap_data_source(config_file, "redcap-penncnb-test", SITE_ID, PROJECT_ID)
     data = fetch_subject_data(data_source, SUBJECT_ID, encryption_passphrase)
@@ -147,8 +147,8 @@ def test_save_subject_data(prod_data_fixture, config_section):
 def test_pull_and_push_single_data(prod_data_fixture, config_section):
     PROJECT_ID, PROJECT_NAME, SITE_ID, SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
 
-    SUBJECT_ID=config.parse(config_file, 'prod-test-info')['subject_id_penncnb']
     config_file = utils.get_config_file_path()
+    SUBJECT_ID=config.parse(config_file, 'prod-test-info')['subject_id_penncnb']
     refresh_all_metadata(config_file, PROJECT_ID, SITE_ID)
     pull_all_data(config_file=config_file,
                   project_id=PROJECT_ID,

--- a/test/lochness/sources/redcap/tasks/test_pull_data.py
+++ b/test/lochness/sources/redcap/tasks/test_pull_data.py
@@ -159,3 +159,20 @@ def test_pull_and_push_single_data(prod_data_fixture, config_section):
     file_path = get_output_file_path(config_file, PROJECT_ID, SITE_ID, SUBJECT_ID, data_source.data_source_name)
     assert_file_and_db(config_file, file_path, PROJECT_ID, SITE_ID, SUBJECT_ID)
     cleanup_output(config_file, PROJECT_ID)
+
+
+def test_pull_all_data(prod_data_fixture):
+    PROJECT_ID, PROJECT_NAME, SITE_ID, SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
+
+    config_file = utils.get_config_file_path()
+    refresh_all_metadata(config_file, PROJECT_ID, SITE_ID)
+    pull_all_data(config_file=config_file,
+                  project_id=PROJECT_ID,
+                  site_id=SITE_ID,
+                  push_to_sink=True)
+
+    for config_section in ['redcap-test', 'redcap-penncnb-test']:
+        data_source = make_redcap_data_source(config_file, config_section, SITE_ID, PROJECT_ID)
+        file_path = get_output_file_path(config_file, PROJECT_ID, SITE_ID, SUBJECT_ID, data_source.data_source_name)
+    assert_file_and_db(config_file, file_path, PROJECT_ID, SITE_ID, SUBJECT_ID)
+    cleanup_output(config_file, PROJECT_ID)

--- a/test/lochness/sources/redcap/tasks/test_pull_data.py
+++ b/test/lochness/sources/redcap/tasks/test_pull_data.py
@@ -44,7 +44,7 @@ def test_fetch_subject_data(prod_data_fixture):
     encryption_passphrase = config.parse(config_file, 'general')[
             'encryption_passphrase']
     redcap_cred = config.parse(config_file, 'redcap-test')
-    data_source_name = 'main_redcap'
+    data_source_name = redcap_cred['data_source_name']
 
     redcapDataSourceMetadata = RedcapDataSourceMetadata(
             keystore_name=redcap_cred['key_name'],
@@ -75,7 +75,7 @@ def test_save_subject_data(prod_data_fixture):
     encryption_passphrase = config.parse(config_file, 'general')[
             'encryption_passphrase']
     redcap_cred = config.parse(config_file, 'redcap-test')
-    data_source_name = 'main_redcap'
+    data_source_name = redcap_cred['data_source_name']
 
     redcapDataSourceMetadata = RedcapDataSourceMetadata(
             keystore_name=redcap_cred['key_name'],
@@ -136,7 +136,8 @@ def test_pull_and_push_single_data(prod_data_fixture):
             PROJECT_ID[1:].lower()
     outdir_root = Path(lochness_root) / project_name_cap
 
-    data_source_name = 'main_redcap'
+    redcap_cred = config.parse(config_file, 'redcap-test')
+    data_source_name = redcap_cred['data_source_name']
     output_dir = (outdir_root
         / "PHOENIX"
         / "PROTECTED"

--- a/test/lochness/sources/redcap/tasks/test_pull_data.py
+++ b/test/lochness/sources/redcap/tasks/test_pull_data.py
@@ -75,13 +75,16 @@ def test_penncnb_fetch_subject_data(prod_data_fixture):
     config_file = utils.get_config_file_path()
     encryption_passphrase = config.parse(config_file, 'general')[
             'encryption_passphrase']
-    redcap_cred = config.parse(config_file, 'redcap-penncnb-test')
-    data_source_name = redcap_cred['data_source_name']
+    redcap_penncnb_cred = config.parse(config_file, 'redcap-penncnb-test')
+    data_source_name = redcap_penncnb_cred['data_source_name']
 
     redcapDataSourceMetadata = RedcapDataSourceMetadata(
-            keystore_name=redcap_cred['key_name'],
-            endpoint_url=redcap_cred['endpoint_url'],
-            subject_id_variable=redcap_cred['subject_id_variable'],
+            keystore_name=redcap_penncnb_cred['key_name'],
+            endpoint_url=redcap_penncnb_cred['endpoint_url'],
+            subject_id_variable=redcap_penncnb_cred['subject_id_variable'],
+            subject_id_variable_as_the_pk=
+                redcap_penncnb_cred['subject_id_variable_as_the_pk'],
+            messy_subject_id=redcap_penncnb_cred['messy_subject_id'],
             optional_variables_dictionary=[])
 
     redcapDataSource = RedcapDataSource(

--- a/test/lochness/sources/redcap/tasks/test_pull_data.py
+++ b/test/lochness/sources/redcap/tasks/test_pull_data.py
@@ -100,7 +100,6 @@ def test_penncnb_fetch_subject_data(prod_data_fixture):
             SUBJECT_ID,
             encryption_passphrase)
 
-    print(data)
     assert len(data) > 100
 
 
@@ -118,6 +117,63 @@ def test_save_subject_data(prod_data_fixture):
             keystore_name=redcap_cred['key_name'],
             endpoint_url=redcap_cred['endpoint_url'],
             subject_id_variable=redcap_cred['subject_id_variable'],
+            subject_id_variable_as_the_pk=
+                redcap_cred['subject_id_variable_as_the_pk'],
+            messy_subject_id=redcap_cred['messy_subject_id'],
+            optional_variables_dictionary=[])
+
+    redcapDataSource = RedcapDataSource(
+        data_source_name=data_source_name,
+        is_active=True,
+        site_id=SITE_ID,
+        project_id=PROJECT_ID,
+        data_source_type='redcap',
+        data_source_metadata=redcapDataSourceMetadata)
+
+    data = fetch_subject_data(
+            redcapDataSource,
+            SUBJECT_ID,
+            encryption_passphrase)
+
+    assert save_subject_data(data, PROJECT_ID, SITE_ID, SUBJECT_ID, 
+                             data_source_name, config_file)
+
+    lochness_root = config.parse(config_file, 'general')['lochness_root']
+    project_name_cap = PROJECT_ID[:1].upper() + \
+            PROJECT_ID[1:].lower()
+
+    output_dir = (
+        Path(lochness_root)
+        / project_name_cap
+        / "PHOENIX"
+        / "PROTECTED"
+        / f"{project_name_cap}{SITE_ID}"
+        / "raw"
+        / SUBJECT_ID
+        / "surveys"
+    )
+    file_name = f"{SUBJECT_ID}.{project_name_cap}.{data_source_name}.json"
+    file_path = output_dir / file_name
+    assert file_path.is_file()
+
+
+def test_penncnb_save_subject_data(prod_data_fixture):
+    PROJECT_ID, PROJECT_NAME, SITE_ID, \
+            SITE_NAME, SUBJECT_ID, DATASINK_NAME = prod_data_fixture
+
+    config_file = utils.get_config_file_path()
+    encryption_passphrase = config.parse(config_file, 'general')[
+            'encryption_passphrase']
+    redcap_penncnb_cred = config.parse(config_file, 'redcap-penncnb-test')
+    data_source_name = redcap_penncnb_cred['data_source_name']
+
+    redcapDataSourceMetadata = RedcapDataSourceMetadata(
+            keystore_name=redcap_penncnb_cred['key_name'],
+            endpoint_url=redcap_penncnb_cred['endpoint_url'],
+            subject_id_variable=redcap_penncnb_cred['subject_id_variable'],
+            subject_id_variable_as_the_pk=
+                redcap_penncnb_cred['subject_id_variable_as_the_pk'],
+            messy_subject_id=redcap_penncnb_cred['messy_subject_id'],
             optional_variables_dictionary=[])
 
     redcapDataSource = RedcapDataSource(
@@ -161,7 +217,6 @@ def test_pull_and_push_single_data(prod_data_fixture):
     config_file = utils.get_config_file_path()
 
     refresh_all_metadata(config_file, PROJECT_ID, SITE_ID)
-
     pull_all_data(config_file=config_file,
                   project_id=PROJECT_ID,
                   site_id=SITE_ID,
@@ -210,4 +265,4 @@ def test_pull_and_push_single_data(prod_data_fixture):
     df = db.execute_sql(config_file, data_push_qeury)
     assert len(df) > 0
 
-    shutil.rmtree(outdir_root)
+    # shutil.rmtree(outdir_root)

--- a/test/lochness/sources/redcap/tasks/test_refresh_metadata.py
+++ b/test/lochness/sources/redcap/tasks/test_refresh_metadata.py
@@ -101,4 +101,5 @@ def test_penncnb_redcap_fetch_metadata(fake_data_fixture):
         data_source_metadata=redcapDataSourceMetadata)
 
     df = fetch_metadata(redcapDataSource, encryption_passphrase)
+    df.to_csv('tmp.csv')
     assert len(df) > 0

--- a/test/lochness/sources/redcap/tasks/test_refresh_metadata.py
+++ b/test/lochness/sources/redcap/tasks/test_refresh_metadata.py
@@ -89,6 +89,7 @@ def test_penncnb_redcap_fetch_metadata(fake_data_fixture):
             keystore_name=redcap_penncnb_cred['key_name'],
             endpoint_url=redcap_penncnb_cred['endpoint_url'],
             optional_variables_dictionary=[],
+            subject_id_variable=redcap_penncnb_cred['subject_id_variable'],
             main_redcap=redcap_penncnb_cred['main_redcap'])
 
     redcapDataSource = RedcapDataSource(
@@ -100,5 +101,4 @@ def test_penncnb_redcap_fetch_metadata(fake_data_fixture):
         data_source_metadata=redcapDataSourceMetadata)
 
     df = fetch_metadata(redcapDataSource, encryption_passphrase)
-    print(df)
     assert len(df) > 0

--- a/test/lochness/sources/redcap/tasks/test_refresh_metadata.py
+++ b/test/lochness/sources/redcap/tasks/test_refresh_metadata.py
@@ -102,4 +102,5 @@ def test_penncnb_redcap_fetch_metadata(fake_data_fixture):
 
     df = fetch_metadata(redcapDataSource, encryption_passphrase)
     df.to_csv('tmp.csv')
+    print(df)
     assert len(df) > 0

--- a/test/lochness/sources/redcap/tasks/test_refresh_metadata.py
+++ b/test/lochness/sources/redcap/tasks/test_refresh_metadata.py
@@ -40,13 +40,14 @@ def test_fetch_metadata(fake_data_fixture):
     encryption_passphrase = config.parse(config_file, 'general')[
             'encryption_passphrase']
     redcap_cred = config.parse(config_file, 'redcap-test')
-    data_source_name = 'main_redcap'
+    data_source_name = redcap_cred['data_source_name']
 
     redcapDataSourceMetadata = RedcapDataSourceMetadata(
             keystore_name=redcap_cred['key_name'],
             endpoint_url=redcap_cred['endpoint_url'],
             subject_id_variable=redcap_cred['subject_id_variable'],
-            optional_variables_dictionary=[])
+            optional_variables_dictionary=[],
+            main_redcap=redcap_cred['main_redcap'])
 
     redcapDataSource = RedcapDataSource(
         data_source_name=data_source_name,
@@ -72,3 +73,32 @@ def test_refresh_all_metadata(fake_data_fixture):
     subject_obj_list = Subject.get_subjects_for_project_site(
             PROJECT_ID, SITE_ID, config_file)
     assert len(subject_obj_list) > 0
+
+
+def test_penncnb_redcap_fetch_metadata(fake_data_fixture):
+    PROJECT_ID, PROJECT_NAME, SITE_ID, \
+            SITE_NAME, SUBJECT_ID, DATASINK_NAME = fake_data_fixture
+
+    config_file = utils.get_config_file_path()
+    encryption_passphrase = config.parse(config_file, 'general')[
+            'encryption_passphrase']
+    redcap_penncnb_cred = config.parse(config_file, 'redcap-penncnb-test')
+    data_source_name = redcap_penncnb_cred['data_source_name']
+
+    redcapDataSourceMetadata = RedcapDataSourceMetadata(
+            keystore_name=redcap_penncnb_cred['key_name'],
+            endpoint_url=redcap_penncnb_cred['endpoint_url'],
+            optional_variables_dictionary=[],
+            main_redcap=redcap_penncnb_cred['main_redcap'])
+
+    redcapDataSource = RedcapDataSource(
+        data_source_name=data_source_name,
+        is_active=True,
+        site_id=SITE_ID,
+        project_id=PROJECT_ID,
+        data_source_type='redcap',
+        data_source_metadata=redcapDataSourceMetadata)
+
+    df = fetch_metadata(redcapDataSource, encryption_passphrase)
+    print(df)
+    assert len(df) > 0

--- a/test/lochness/tasks/test_push_data.py
+++ b/test/lochness/tasks/test_push_data.py
@@ -49,6 +49,7 @@ def test_push_file_to_sink(fake_data_fixture):
     file_obj.modality = 'surveys'
 
     config_file = utils.get_config_file_path()
+    redcap_cred = config.parse(config_file, 'redcap-test')
     minio_cred = config.parse(config_file, 'datasink-test')
     dataSink = DataSink.get_matching_data_sink(
             config_file=config_file,
@@ -61,7 +62,7 @@ def test_push_file_to_sink(fake_data_fixture):
     result = push_file_to_sink(file_obj=file_obj,
                                modality=file_obj.modality,
                                dataSink=dataSink,
-                               data_source_name='main_redcap',
+                               data_source_name=redcap_cred['data_source_name'],
                                project_id=PROJECT_ID,
                                site_id=SITE_ID,
                                subject_id=SUBJECT_ID,

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -55,7 +55,7 @@ def create_fake_records(project_id, project_name, site_id,
             'encryption_passphrase']
 
     redcap_cred = config.parse(config_file, 'redcap-test')
-    # create key store
+    # create key store the main redcap
     keystore = KeyStore(
             key_name=redcap_cred['key_name'],
             key_value=redcap_cred['key_value'],
@@ -65,8 +65,19 @@ def create_fake_records(project_id, project_name, site_id,
     db.execute_queries(config_file,
                        [keystore.to_sql_query(encryption_passphrase)])
 
+    # create key store for penn redcap
+    redcap_penncnb_cred = config.parse(config_file, 'redcap-penncnb-test')
+    keystore = KeyStore(
+            key_name=redcap_penncnb_cred['key_name'],
+            key_value=redcap_penncnb_cred['key_value'],
+            key_type=redcap_penncnb_cred['key_type'],
+            project_id=project_id,
+            key_metadata={})
+    db.execute_queries(config_file,
+                       [keystore.to_sql_query(encryption_passphrase)])
+
+    # create key store for data sink
     minio_cred = config.parse(config_file, 'datasink-test')
-    # create key store
     keystore = KeyStore(
             key_name=minio_cred['key_name'],
             key_value=minio_cred['key_value'],
@@ -116,9 +127,9 @@ def create_fake_records(project_id, project_name, site_id,
     db.execute_queries(config_file, [subject.to_sql_query()])
 
 
-    # create fake data source
+    # create fake data source for main redcap
     dataSource = DataSource(
-            data_source_name='main_redcap',
+            data_source_name=redcap_cred['data_source_name'],
             is_active=True,
             site_id=site_id,
             project_id=project_id,
@@ -129,10 +140,27 @@ def create_fake_records(project_id, project_name, site_id,
                 'keystore_name': redcap_cred['key_name'],
                 'endpoint_url': redcap_cred['endpoint_url'],
                 'subject_id_variable': redcap_cred['subject_id_variable'],
+                'main_redcap': redcap_cred['main_redcap']
                 }
             )
     db.execute_queries(config_file, [dataSource.to_sql_query()])
 
+    # create fake data source for penncnb redcap
+    dataSource = DataSource(
+            data_source_name=redcap_penncnb_cred['data_source_name'],
+            is_active=True,
+            site_id=site_id,
+            project_id=project_id,
+            data_source_type='redcap',
+            data_source_metadata={
+                'testing': True,
+                'modality': 'surveys',
+                'keystore_name': redcap_penncnb_cred['key_name'],
+                'endpoint_url': redcap_penncnb_cred['endpoint_url'],
+                'subject_id_variable': redcap_penncnb_cred['subject_id_variable'],
+                'main_redcap': redcap_penncnb_cred['main_redcap']
+                })
+    db.execute_queries(config_file, [dataSource.to_sql_query()])
 
     test_file = Path('test_file.zip')
     test_file.touch()
@@ -145,7 +173,7 @@ def create_fake_records(project_id, project_name, site_id,
 
     dataPull = DataPull(
         subject_id=subject_id,
-        data_source_name='main_redcap',
+        data_source_name=redcap_cred['data_source_name'],
         site_id=site_id,
         project_id=project_id,
         file_path=str(test_file),
@@ -238,6 +266,8 @@ def test_pipeline_with_fake_data(fake_data_fixture):
 
 def delete_fake_records(project_id, project_name, site_id,
                         site_name, subject_id, datasink_name):
+    redcap_cred = config.parse(config_file, 'redcap-test')
+    redcap_penncnb_cred = config.parse(config_file, 'redcap-penncnb-test')
     test_file = Path('test_file.zip')
 
     fileObj = File(
@@ -254,7 +284,7 @@ def delete_fake_records(project_id, project_name, site_id,
 
     dataPull = DataPull(
         subject_id=subject_id,
-        data_source_name='main_redcap',
+        data_source_name=redcap_cred['data_source_name'],
         site_id=site_id,
         project_id=project_id,
         file_path=str(test_file),
@@ -283,7 +313,17 @@ def delete_fake_records(project_id, project_name, site_id,
 
     # delete fake data source
     dataSource = DataSource(
-            data_source_name='main_redcap',
+            data_source_name=redcap_cred['data_source_name'],
+            is_active=True,
+            site_id=site_id,
+            project_id=project_id,
+            data_source_type='redcap',
+            data_source_metadata={}
+            )
+    db.execute_queries(config_file, [dataSource.delete_record_query()])
+
+    dataSource = DataSource(
+            data_source_name=redcap_penncnb_cred['data_source_name'],
             is_active=True,
             site_id=site_id,
             project_id=project_id,
@@ -311,12 +351,20 @@ def delete_fake_records(project_id, project_name, site_id,
     db.execute_queries(config_file, [site.delete_record_query()])
 
 
-    redcap_cred = config.parse(config_file, 'redcap-test')
     # delete key store
     keystore = KeyStore(
             key_name=redcap_cred['key_name'],
             key_value=redcap_cred['key_value'],
             key_type=redcap_cred['key_type'],
+            project_id=project_id,
+            key_metadata={})
+    db.execute_queries(config_file,
+                       [keystore.delete_record_query()])
+
+    keystore = KeyStore(
+            key_name=redcap_penncnb_cred['key_name'],
+            key_value=redcap_penncnb_cred['key_value'],
+            key_type=redcap_penncnb_cred['key_type'],
             project_id=project_id,
             key_metadata={})
     db.execute_queries(config_file,

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -140,6 +140,10 @@ def create_fake_records(project_id, project_name, site_id,
                 'keystore_name': redcap_cred['key_name'],
                 'endpoint_url': redcap_cred['endpoint_url'],
                 'subject_id_variable': redcap_cred['subject_id_variable'],
+                'subject_id_variable_as_the_pk': 
+                    redcap_cred['subject_id_variable_as_the_pk'],
+                'messy_subject_id': 
+                    redcap_cred['messy_subject_id'],
                 'main_redcap': redcap_cred['main_redcap']
                 }
             )
@@ -158,6 +162,10 @@ def create_fake_records(project_id, project_name, site_id,
                 'keystore_name': redcap_penncnb_cred['key_name'],
                 'endpoint_url': redcap_penncnb_cred['endpoint_url'],
                 'subject_id_variable': redcap_penncnb_cred['subject_id_variable'],
+                'subject_id_variable_as_the_pk': 
+                    redcap_penncnb_cred['subject_id_variable_as_the_pk'],
+                'messy_subject_id': 
+                    redcap_penncnb_cred['messy_subject_id'],
                 'main_redcap': redcap_penncnb_cred['main_redcap']
                 })
     db.execute_queries(config_file, [dataSource.to_sql_query()])


### PR DESCRIPTION
This PR mainly updates the REDCap dataflow of the pipeline, which came up during the testing of the Penn CNB REDCap.

Unique characterizations of the Penn CNB REDCap include
- refresh_metadata function shouldn't run on this REDCap, but limited to the `main_redcap`
- Penn CNB REDCap stores the subject ID in a non-primary key field, occasionally with special characters denoting the timepoint

To deal with above
- This PR updates the REDCapDataSourceMetadata object to require more descriptions about the REDCap source. This allows the pipeline to skip updating subjects records from `refresh_metadata.py` and also to use different API calls.
- Added a logic to query the right REDCap data using the non-primary key field.
- Tests are updated

This PR should be reviewed after https://github.com/dheshanm/lochness/pull/14

