### PR TITLE
feat: Drop subjects from getting imported if missing required variables

### DIFF
--- a/test/setup.json
+++ b/test/setup.json
@@ -40,6 +40,12 @@
                         "variable_name": "chrdbb_lamp_id",
                         "variable_description": "MINDLAMP ID",
                         "internal_name": "mindlamp_id"
+                    },
+                    {
+                        "variable_name": "chric_consent_date",
+                        "variable_description": "Consent Date",
+                        "internal_name": "consent_date",
+                        "required": true
                     }
                 ]
             }


### PR DESCRIPTION
Addresses #36.

Introduces a validation mechanism for subject imports, preventing subjects with missing required variables from being imported into the database.

- Added a new field required to the optional_variables_dictionary in setup.json to specify variables that must be present for a subject to be imported
- Updated `lochness/sources/redcap/tasks/refresh_metadata.py` to implement and enforce this validation requirement
- Refactored code by extracting `flatten_by_subject_id(df: pd.DataFrame) -> pd.DataFrame` into a separate function