### PR TITLE
Updated Teams Forms to Microsoft Forms paths

### DIFF
--- a/lochness/scripts/import_setup_json.py
+++ b/lochness/scripts/import_setup_json.py
@@ -30,6 +30,7 @@ from rich.logging import RichHandler
 from lochness.helpers import logs, utils, db, config
 from lochness.models.projects import Project
 from lochness.models.sites import Site
+from lochness.models.subjects import Subject
 from lochness.models.data_source import DataSource
 from lochness.models.data_sinks import DataSink
 from lochness.models.keystore import KeyStore
@@ -74,6 +75,10 @@ def import_setup_json(setup_json: Path, config_file: Path) -> None:
     for site_data in setup_data.get("sites", []):
         site = Site(**site_data)
         queries.append(site.to_sql_query())
+
+    for subject_data in setup_data.get("subjects", []):
+        subject = Subject(**subject_data)
+        queries.append(subject.to_sql_query())
 
     for ds_data in setup_data.get("data_sources", []):
         data_source = DataSource(**ds_data)

--- a/lochness/sources/sharepoint/models/data_source.py
+++ b/lochness/sources/sharepoint/models/data_source.py
@@ -18,6 +18,7 @@ class SharepointDataSourceMetadata(BaseModel):
     keystore_name: str
     site_url: str
     form_name: str
+    form_title: str
     modality: str
     drive_name: str
 
@@ -79,8 +80,10 @@ class SharepointDataSource(BaseModel):
                 data_source_metadata=SharepointDataSourceMetadata(
                     keystore_name=row["data_source_metadata"]["keystore_name"],
                     site_url=row["data_source_metadata"]["site_url"],
+                    form_title=row["data_source_metadata"]["form_title"],
                     form_name=row["data_source_metadata"]["form_name"],
                     modality=row["data_source_metadata"]["modality"],
+                    drive_name=row["data_source_metadata"]["drive_name"],
                 ),
             )
             return sharepoint_data_source

--- a/lochness/sources/sharepoint/tasks/pull_data.py
+++ b/lochness/sources/sharepoint/tasks/pull_data.py
@@ -68,6 +68,7 @@ def fetch_subject_data(
 
     metadata = sharepoint_data_source.data_source_metadata
     form_name = metadata.form_name
+    form_title = metadata.form_title
     modality = getattr(metadata, "modality", "unknown")
 
     identifier = f"{project_id}::{site_id}::{data_source_name}::{subject_id}"
@@ -128,6 +129,7 @@ def fetch_subject_data(
         / subject_id
         / modality
     )
+
     subject_folders = sharepoint_utils.get_matching_subfolders(
         drive_id, site_folder, form_name, headers
     )
@@ -136,14 +138,15 @@ def fetch_subject_data(
         if subject_folder['name'] == subject_id:
             logger.info(f"Found corresponding subfolder for {subject_id}")
             session_folders = sharepoint_utils.get_matching_subfolders(
-                drive_id, subject_folder, subject_id, headers
+                drive_id, subject_folder, subject_id, headers,
+                relaxed_search=True
             )
             for session_folder in session_folders:
                 sharepoint_utils.download_new_or_updated_files(
                     session_folder,
                     drive_id,
                     headers,
-                    form_name,
+                    form_title,
                     subject_id,
                     site_id,
                     project_id,

--- a/lochness/sources/sharepoint/utils.py
+++ b/lochness/sources/sharepoint/utils.py
@@ -125,22 +125,57 @@ def find_subfolder(
     return None
 
 
-def get_matching_subfolders(
+def find_subfolders(
     drive_id: str,
-    responses_folder: Dict,
-    form_name: str,
+    parent_id: str,
+    subfolder_name_patt: str,
     headers: Dict[str, str],
     timeout: int = 120,
+) -> Optional[List[Dict]]:
+    """
+    Find subfolders by subfolder name pattern within a specified parent folder.
+
+    Args:
+        drive_id (str): The SharePoint drive ID.
+        parent_id (str): The parent folder ID.
+        subfolder_name_patt (str): The name pattern of the subfolders to find.
+        headers (Dict[str, str]): Headers containing the access token.
+        timeout (int): Request timeout in seconds.
+    Returns:
+        Optional[Dict]: The subfolder item if found, else None.
+    """
+    subfolders = []
+    for item in sharepoint_api.list_folder_items(
+        drive_id, parent_id, headers, timeout=timeout
+    ):
+        if subfolder_name_patt.lower() in item.get("name", "").lower() and "folder" in item:
+            logger.info(f"Found subfolder '{subfolder_name_patt}' in parent {parent_id}")
+            subfolders.append(item)
+
+    if subfolders == "":
+        logger.warning(f"Subfolder matching '{subfolder_name_patt}' pattern not found in parent {parent_id}")
+        return None
+
+    return subfolders
+
+def get_matching_subfolders(
+    drive_id: str,
+    ms_folder_dict: Dict,
+    subdir_name: str,
+    headers: Dict[str, str],
+    timeout: int = 120,
+    relaxed_search: bool = False
 ) -> List[Dict]:
     """
     Get subfolders matching a specific form name within the 'Responses' folder.
 
     Args:
         drive_id (str): The SharePoint drive ID.
-        responses_folder (Dict): The 'Responses' folder item.
-        form_name (str): The name of the form to match subfolders.
+        ms_folder_dict (Dict): The Sharepoint folder item.
+        subdir_name (str): The name of the form to match subfolders.
         headers (Dict[str, str]): Headers containing the access token.
         timeout (int): Request timeout in seconds.
+        relaxed_search (bool): Find patterns that include the subdir_name instead of exact match.
 
     Returns:
         List[Dict]: A list of matching subfolders.
@@ -148,20 +183,32 @@ def get_matching_subfolders(
     Raises:
         RuntimeError: If the 'Responses' folder or matching form folder is not found.
     """
+    if relaxed_search:
+        subfolders = find_subfolders(
+            drive_id, ms_folder_dict["id"], subdir_name,
+            headers,
+            timeout=timeout
+        )
+        if not subfolders:
+            logger.info(f"No subfolders found in '{subdir_name}'.")
+        else:
+            logger.info(f"Found {len(subfolders)} subfolders for form:'{subdir_name}'.")
+        return subfolders
+
     matching_folder = find_subfolder(
-        drive_id, responses_folder["id"], form_name, headers, timeout=timeout
+        drive_id, ms_folder_dict["id"], subdir_name, headers, timeout=timeout
     )
 
     if not matching_folder:
-        raise RuntimeError(f"'{form_name}' folder not found inside 'Responses'.")
+        raise RuntimeError(f"'{subdir_name}' folder not found inside {ms_folder_dict['name']}.")
 
     subfolders = sharepoint_api.list_folder_items(
         drive_id, matching_folder["id"], headers, timeout=timeout
     )
     if not subfolders:
-        logger.info(f"No subfolders found in '{form_name}'.")
+        logger.info(f"No subfolders found in '{subdir_name}'.")
     else:
-        logger.info(f"Found {len(subfolders)} subfolders for form:'{form_name}'.")
+        logger.info(f"Found {len(subfolders)} subfolders for form:'{subdir_name}'.")
 
     return subfolders
 
@@ -261,7 +308,7 @@ def extract_info(
         pass
 
     try:
-        date_str = data.get("data", {}).get("data", {}).get("dateOfEgg")
+        date_str = data.get("data", {}).get("data", {}).get("dateOfEeg")
         dt = datetime.fromisoformat(date_str)
         # date_only = dt.date()
         dt_str = dt.strftime("%Y_%m_%d")


### PR DESCRIPTION
EEG form uploads now have the following path:
`Documents/ProCAN/{site}/EEG/{subject}/{subject}_{YYYY}_{MM}_{DD}`

The script now confirms the presence of the site folder (should always exist) and subject folder (will only exist if a response has been filled out for this subject).