### PR TITLE
fix: Add missing required variables to `subject_metadata`

### DIFF
--- a/lochness/models/subjects.py
+++ b/lochness/models/subjects.py
@@ -201,6 +201,10 @@ class Subject(BaseModel):
         SELECT *
         FROM subjects
         WHERE project_id = '{project_id}' AND site_id = '{site_id}'
+            AND (
+                subject_metadata->>'missing_required_variables' IS NULL OR
+                subject_metadata->>'missing_required_variables' = ''
+            )
         """
 
         # Dynamically append WHERE clauses for each metadata filter
@@ -269,7 +273,10 @@ class Subject(BaseModel):
             subject_id, site_id, project_id, subject_metadata
         FROM subjects
         WHERE project_id = '{project_id}' AND
-            site_id = '{site_id}';
+            site_id = '{site_id}' AND (
+                subject_metadata->>'missing_required_variables' IS NULL OR
+                subject_metadata->>'missing_required_variables' = ''
+            )
         """
         subjects_df = db.execute_sql(config_file, query)
 

--- a/lochness/sources/redcap/tasks/refresh_metadata.py
+++ b/lochness/sources/redcap/tasks/refresh_metadata.py
@@ -238,8 +238,33 @@ def fetch_metadata(
     flattened_df = flatten_by_subject_id(df)
 
     # Drop rows without required variables
-    for required_variable in required_variables:
-        flattened_df = flattened_df[flattened_df[required_variable].notna()]
+    # for required_variable in required_variables:
+    #     flattened_df = flattened_df[flattened_df[required_variable].notna()]
+
+    for idx, row in flattened_df.iterrows():  # type: ignore
+        missing_required_vars: List[str] = []
+        for required_variable in required_variables:
+            if pd.isna(row.get(required_variable)):
+                missing_required_vars.append(required_variable)
+        if missing_required_vars:
+            log_event(
+                config_file=config_file,
+                log_level="WARNING",
+                event="redcap_metadata_fetch_missing_required_variable",
+                message=(
+                    f"Record with subject_id {row['subject_id']} is missing required "
+                    f"variables: {', '.join(missing_required_vars)}."
+                ),
+                project_id=project_id,
+                site_id=site_id,
+                data_source_name=data_source_name,
+                extra={"subject_id": row["subject_id"], "missing_variables": missing_required_vars},
+            )
+            # Add a column to indicate missing required variables
+            flattened_df.at[idx, "missing_required_variables"] = ", ".join(missing_required_vars)
+        else:
+            flattened_df.at[idx, "missing_required_variables"] = ""
+
 
     flattened_df = flattened_df.reset_index(drop=True)
     return pd.DataFrame(flattened_df)


### PR DESCRIPTION
Closes #58

We now track a subject's missing required variables and exclude subjects with missing required variables from subsequent pull_data requests from DataSources.

This will still allow manually forcing subject data pulls, but will prevent data pulls when run as pat of a network-wide or site-wide pull