### PR TITLE
feat: Add support for redaction options in REDCap data source metadata

### DIFF
--- a/lochness/sources/redcap/models/data_source.py
+++ b/lochness/sources/redcap/models/data_source.py
@@ -19,7 +19,7 @@ class RedcapDataSourceMetadata(BaseModel):
 
     keystore_name: str
     endpoint_url: str
-    optional_variables_dictionary: List[Dict[str, str]]
+    optional_variables_dictionary: List[Dict[str, str]] = Field(default_factory=list)
     main_redcap: bool = False
     subject_id_variable: Optional[str]
     subject_id_variable_as_the_pk: bool = True

--- a/lochness/sources/redcap/models/data_source.py
+++ b/lochness/sources/redcap/models/data_source.py
@@ -24,6 +24,8 @@ class RedcapDataSourceMetadata(BaseModel):
     subject_id_variable: Optional[str]
     subject_id_variable_as_the_pk: bool = True
     messy_subject_id: bool = False
+    redact_all_identifiers: bool = False
+    redact_fields_list: List[str] = Field(default_factory=list)
     dictionary: Optional[List[Dict[str, Any]]] = Field(
         repr=False,
         default=None
@@ -107,6 +109,12 @@ class RedcapDataSource(BaseModel):
                     ],
                     optional_variables_dictionary=optional_variables,
                     main_redcap=row["data_source_metadata"]["main_redcap"],
+                    redact_all_identifiers=row["data_source_metadata"][
+                        "redact_all_identifiers"
+                    ],
+                    redact_fields_list=row["data_source_metadata"][
+                        "redact_fields_list"
+                    ],
                     dictionary=row["data_source_metadata"].get("dictionary")
                 ),
             )

--- a/lochness/sources/redcap/models/data_source.py
+++ b/lochness/sources/redcap/models/data_source.py
@@ -80,15 +80,6 @@ class RedcapDataSource(BaseModel):
             Returns:
                 RedcapDataSource: A RedcapDataSource object.
             """
-            # Handle missing optional_variables_dictionary with default empty list
-            optional_variables = (
-                row["data_source_metadata"]
-                .get(
-                    "optional_variables_dictionary",
-                    []
-                )
-            )
-
             redcap_data_source = RedcapDataSource(
                 data_source_name=row["data_source_name"],
                 is_active=row["data_source_is_active"],
@@ -96,26 +87,7 @@ class RedcapDataSource(BaseModel):
                 project_id=row["project_id"],
                 data_source_type=row["data_source_type"],
                 data_source_metadata=RedcapDataSourceMetadata(
-                    keystore_name=row["data_source_metadata"]["keystore_name"],
-                    endpoint_url=row["data_source_metadata"]["endpoint_url"],
-                    subject_id_variable=row["data_source_metadata"][
-                        "subject_id_variable"
-                    ],
-                    messy_subject_id=row["data_source_metadata"][
-                        "messy_subject_id"
-                    ],
-                    subject_id_variable_as_the_pk=row["data_source_metadata"][
-                        "subject_id_variable_as_the_pk"
-                    ],
-                    optional_variables_dictionary=optional_variables,
-                    main_redcap=row["data_source_metadata"]["main_redcap"],
-                    redact_all_identifiers=row["data_source_metadata"][
-                        "redact_all_identifiers"
-                    ],
-                    redact_fields_list=row["data_source_metadata"][
-                        "redact_fields_list"
-                    ],
-                    dictionary=row["data_source_metadata"].get("dictionary")
+                    **row["data_source_metadata"]
                 ),
             )
             return redcap_data_source

--- a/lochness/sources/redcap/tasks/pull_data.py
+++ b/lochness/sources/redcap/tasks/pull_data.py
@@ -155,7 +155,6 @@ def fetch_subject_data(
     redcap_data_source: RedcapDataSource,
     subject_id: str,
     config_file: Path,
-    redact_identifiers: bool = True,
     timeout_s: int = 60,
 ) -> Tuple[Optional[List[Dict[str, Any]]], Optional[List[Dict[str, Any]]]]:
     """
@@ -264,11 +263,15 @@ def fetch_subject_data(
         return None, logs_result
 
     # Redact identifers
-    if redact_identifiers:
+    if redcap_data_source.data_source_metadata.redact_all_identifiers:
         identifier_fields = redcap_utils.get_identifier_fields_from_data_source(
             redcap_data_source
         )
         data_result = redcap_utils.redact_identifiers(data_result, identifier_fields)
+    if redcap_data_source.data_source_metadata.redact_fields_list:
+        data_result = redcap_utils.redact_identifiers(
+            data_result, redcap_data_source.data_source_metadata.redact_fields_list
+        )
 
     return data_result, logs_result
 


### PR DESCRIPTION
Allow Configuring redaction options from `RedcapDataSource.data_source_metadata`.

This PR provides:
- `redact_all_identifiers` (`bool`): Where all 'identifiers' (from Data Dictionary) are redacted
- `redact_fields_list` (`List[str]`): Where any passed variables are redacted

A combination of these can be used to satisfy most requirements