### PR TITLE
fix: Redcap data dictionary overlap

### DIFF
--- a/dags/redcap_data_dictionary_sync.py
+++ b/dags/redcap_data_dictionary_sync.py
@@ -15,6 +15,7 @@ The synchronization process:
 Parameters:
     - project_id: Optional project ID to limit sync scope
     - site_id: Optional site ID to limit sync scope
+    - data_source_name: Optional data source name to limit sync scope
     - dry_run: When True, performs checks without updating the database
 """
 
@@ -74,6 +75,15 @@ with DAG(
                 ),
                 title="Site ID",
             ),
+            "data_source_name": Param(
+                default=None,
+                type=["null", "string"],
+                description=(
+                    "Optional: Limit sync to a specific REDCap data source name. "
+                    "Leave empty to sync all data sources."
+                ),
+                title="Data Source Name",
+            ),
             "dry_run": Param(
                 default=False,
                 type=["null", "boolean"],
@@ -109,6 +119,7 @@ echo "LOCHNESS_REPO_ROOT: {{ var.value['LOCHNESS_REPO_ROOT'] }}"
 echo "LOCHNESS_PYTHON_PATH: {{ var.value['LOCHNESS_PYTHON_PATH'] }}"
 echo "Project ID: {{ params.project_id or 'ALL' }}"
 echo "Site ID: {{ params.site_id or 'ALL' }}"
+echo "Data Source Name: {{ params.data_source_name or 'ALL' }}"
 echo "Dry Run: {{ params.dry_run }}"
 echo "=================================="''',
         cwd="{{ var.value['LOCHNESS_REPO_ROOT'] }}",
@@ -122,7 +133,8 @@ echo "=================================="''',
             "{{ var.value['LOCHNESS_REPO_ROOT'] }}/lochness/sources/redcap/tasks/"
             "pull_dictionary.py "
             "{% if params.project_id %} --project_id {{ params.project_id }}{% endif %} "
-            "{% if params.site_id %} --site_id {{ params.site_id }}{% endif %}"
+            "{% if params.site_id %} --site_id {{ params.site_id }}{% endif %} "
+            "{% if params.data_source_name %} --data_source_name {{ params.data_source_name }}{% endif %}"
         ),
         cwd="{{ var.value['LOCHNESS_REPO_ROOT'] }}",
         outlets=[redcap_data_dictionary_asset],

--- a/lochness/sources/redcap/models/data_source.py
+++ b/lochness/sources/redcap/models/data_source.py
@@ -125,6 +125,7 @@ class RedcapDataSource(BaseModel):
         config_file: Path,
         project_id: str,
         site_id: str,
+        data_source_name: str,
         dictionary: List[Dict[str, Any]],
     ) -> None:
         """
@@ -150,6 +151,7 @@ class RedcapDataSource(BaseModel):
         )
         WHERE project_id = '{project_id}'
             AND site_id = '{site_id}'
+            AND data_source_name = '{data_source_name}'
             AND data_source_type = 'redcap'
         """
 

--- a/lochness/sources/redcap/tasks/pull_dictionary.py
+++ b/lochness/sources/redcap/tasks/pull_dictionary.py
@@ -182,6 +182,7 @@ def fetch_dictionary(
             config_file=config_file,
             project_id=project_id,
             site_id=site_id,
+            data_source_name=data_source_name,
             dictionary=raw_data,
         )
     else:
@@ -205,6 +206,7 @@ def fetch_dictionary(
             config_file=config_file,
             project_id=project_id,
             site_id=site_id,
+            data_source_name=data_source_name,
             dictionary=raw_data,
         )
 
@@ -212,7 +214,7 @@ def fetch_dictionary(
 
 
 def refresh_redcap_dictionary(
-    config_file: Path, project_id: Optional[str] = None, site_id: Optional[str] = None
+    config_file: Path, project_id: Optional[str] = None, site_id: Optional[str] = None, data_source_name: Optional[str] = None
 ) -> None:
     """
     Refreshes the metadata for all active REDCap data sources in the database.
@@ -221,7 +223,7 @@ def refresh_redcap_dictionary(
         config_file (Path): Path to the config file.
         project_id (Optional[str]): If provided, only refresh this project ID.
         site_id (Optional[str]): If provided, only refresh this site ID.
-
+        data_source_name (Optional[str]): If provided, only refresh this data source name.
     Returns:
         None
     """
@@ -252,6 +254,10 @@ def refresh_redcap_dictionary(
     if site_id:
         active_redcap_data_sources = [
             ds for ds in active_redcap_data_sources if ds.site_id == site_id
+        ]
+    if data_source_name:
+        active_redcap_data_sources = [
+            ds for ds in active_redcap_data_sources if ds.data_source_name == data_source_name
         ]
 
     if not active_redcap_data_sources:
@@ -304,6 +310,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--site_id", type=str, default=None, help="Site ID to refresh (optional)"
     )
+    parser.add_argument(
+        "--data_source_name", type=str, default=None, help="Data source name to refresh (optional)"
+    )
     args = parser.parse_args()
 
     config_file = utils.get_config_file_path()
@@ -319,7 +328,7 @@ if __name__ == "__main__":
 
     logger.info("Refreshing REDCap dictionary...")
     refresh_redcap_dictionary(
-        config_file=config_file, project_id=args.project_id, site_id=args.site_id
+        config_file=config_file, project_id=args.project_id, site_id=args.site_id, data_source_name=args.data_source_name
     )
 
     logger.info("Finished refreshing REDCap dictionary.")
@@ -330,4 +339,5 @@ if __name__ == "__main__":
         message="Finished REDCap dictionary refresh process.",
         project_id=args.project_id,
         site_id=args.site_id,
+        data_source_name=args.data_source_name,
     )

--- a/lochness/sources/redcap/tasks/pull_dictionary.py
+++ b/lochness/sources/redcap/tasks/pull_dictionary.py
@@ -241,11 +241,6 @@ def refresh_redcap_dictionary(
         active_only=True,
     )
 
-    # make sure they have subject_id_variable in metadata
-    active_redcap_data_sources = [
-        ds for ds in active_redcap_data_sources if ds.data_source_metadata.main_redcap
-    ]
-
     # Filter by project_id and/or site_id if provided
     if project_id:
         active_redcap_data_sources = [


### PR DESCRIPTION
Previously REDCap metadata (Data Dictionary) got updated at site level, instead of Data Source level, causing sites with multiple REDCap data sources to have incompatible Data Dictionaries registered.